### PR TITLE
Update benchmark.php

### DIFF
--- a/benchmark.php
+++ b/benchmark.php
@@ -176,7 +176,7 @@ function test_math(&$result, $count = 99999)
 {
     $timeStart = microtime(true);
 
-    $mathFunctions = array("abs", "acos", "asin", "atan", "bindec", "floor", "exp", "sin", "tan", "pi", "is_finite", "is_nan", "sqrt");
+    $mathFunctions = array("abs", "acos", "asin", "atan", "bindec", "floor", "exp", "sin", "tan", "is_finite", "is_nan", "sqrt");
     for ($i = 0; $i < $count; $i++) {
         foreach ($mathFunctions as $function) {
             call_user_func_array($function, array($i));


### PR DESCRIPTION
Stripped out the pi maths function.
It doesn't really do any maths, just returns a constant float M_PI which doesn't really benchmark PHP mathematical performance.

(See: /ext/standard/php_math.h:#define M_PI           3.14159265358979323846  /* pi */)

Also as of PHP 8.0 it will throw a PHP Fatal error if you pass an argument to the pi function:

PHP Fatal error:  Uncaught ArgumentCountError: pi() expects exactly 0 arguments, 1 given in /var/www/html/benchmark.php:182